### PR TITLE
New authenticator controller

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -3,13 +3,13 @@
 namespace PragmaRX\Google2FALaravel;
 
 use Closure;
-use PragmaRX\Google2FALaravel\Support\Authenticator;
+use PragmaRX\Google2FALaravel\Support\AuthenticatorController;
 
 class Middleware
 {
     public function handle($request, Closure $next)
     {
-        $authenticator = app(Authenticator::class)->boot($request);
+        $authenticator = app(AuthenticatorController::class)->boot($request);
 
         if ($authenticator->isAuthenticated()) {
             return $next($request);

--- a/src/Support/Auth.php
+++ b/src/Support/Auth.php
@@ -34,6 +34,6 @@ trait Auth
     {
         return $this->getAuth()->user();
     }
-    
+
     abstract public function config($string, $children = []);
 }

--- a/src/Support/Auth.php
+++ b/src/Support/Auth.php
@@ -25,5 +25,15 @@ trait Auth
         return $this->auth;
     }
 
+    /**
+     * Get the current user.
+     *
+     * @return mixed
+     */
+    protected function getUser()
+    {
+        return $this->getAuth()->user();
+    }
+    
     abstract public function config($string, $children = []);
 }

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -11,7 +11,7 @@ use PragmaRX\Google2FALaravel\Exceptions\InvalidSecretKey;
 
 class Authenticator
 {
-    use Auth, Config, ErrorBag, Request, Session;
+    use Auth, Config, Request, Session;
 
     /**
      * Authenticator constructor.
@@ -58,10 +58,9 @@ class Authenticator
      *
      * @return mixed
      */
-    public function getGoogle2FASecretKey()
+    protected function getGoogle2FASecretKey()
     {
         $secret = $this->getUser()->{$this->config('otp_secret_column')};
-
         return $secret;
     }
 
@@ -70,7 +69,7 @@ class Authenticator
      * 
      * @return bool
      */
-    protected function isActivated()
+    public function isActivated()
     {
         $secret = $this->getGoogle2FASecretKey();
         return !is_null($secret) && !empty($secret);
@@ -141,7 +140,7 @@ class Authenticator
     /**
      * Set current auth as valid.
      */
-    public function storeAuthPassed()
+    public function login()
     {
         $this->sessionPut(Constants::SESSION_AUTH_PASSED, true);
 
@@ -213,4 +212,20 @@ class Authenticator
                 $this->getOldOneTimePassword() ?: Google2FAConstants::ARGUMENT_NOT_SET
         );
     }
+
+    /**
+     * Verify the OTP.
+     *
+     * @return mixed
+     */
+    public function verifyAndStoreOneTimePassord($one_time_password)
+    {
+        return $this->storeOldOneTimePassord(
+            $this->verifyGoogle2FA(
+                $this->getGoogle2FASecretKey(),
+                $one_time_password
+            )
+        );
+    }
+    
 }

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -76,11 +76,25 @@ class Authenticator
     }
 
     /**
+     * Store the old OTP.
+     *
+     * @param $key
+     *
+     * @return mixed
+     */
+    protected function storeOldTimestamp($key)
+    {
+        return $this->config('forbid_old_passwords') === true
+            ? $this->sessionPut(Constants::SESSION_OTP_TIMESTAMP, $key)
+            : $key;
+    }
+
+    /**
      * Get the previous OTP.
      *
      * @return null|void
      */
-    protected function getOldOneTimePassword()
+    protected function getOldTimestamp()
     {
         return $this->config('forbid_old_passwords') === true
             ? $this->sessionGet(Constants::SESSION_OTP_TIMESTAMP)
@@ -138,28 +152,6 @@ class Authenticator
     }
 
     /**
-     * Set current auth as valid.
-     */
-    public function login()
-    {
-        $this->sessionPut(Constants::SESSION_AUTH_PASSED, true);
-
-        $this->updateCurrentAuthTime();
-    }
-
-    /**
-     * Store the old OTP.
-     *
-     * @param $key
-     *
-     * @return mixed
-     */
-    public function storeOldOneTimePassord($key)
-    {
-        return $this->sessionPut(Constants::SESSION_OTP_TIMESTAMP, $key);
-    }
-
-    /**
      * Verifies, in the current session, if a 2fa check has already passed.
      *
      * @return bool
@@ -179,6 +171,16 @@ class Authenticator
     protected function isEnabled()
     {
         return $this->config('enabled');
+    }
+
+    /**
+     * Set current auth as valid.
+     */
+    public function login()
+    {
+        $this->sessionPut(Constants::SESSION_AUTH_PASSED, true);
+
+        $this->updateCurrentAuthTime();
     }
 
     /**
@@ -209,7 +211,7 @@ class Authenticator
                 $one_time_password,
                 $this->config('window'),
                 null, // $timestamp
-                $this->getOldOneTimePassword() ?: Google2FAConstants::ARGUMENT_NOT_SET
+                $this->getOldTimestamp() ?: Google2FAConstants::ARGUMENT_NOT_SET
         );
     }
 
@@ -220,7 +222,7 @@ class Authenticator
      */
     public function verifyAndStoreOneTimePassord($one_time_password)
     {
-        return $this->storeOldOneTimePassord(
+        return $this->storeOldTimeStamp(
             $this->verifyGoogle2FA(
                 $this->getGoogle2FASecretKey(),
                 $one_time_password

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -32,6 +32,7 @@ class Authenticator
     public function boot($request)
     {
         $this->setRequest($request);
+
         return $this;
     }
 
@@ -63,7 +64,7 @@ class Authenticator
 
     /**
      * Check if the 2FA is activated for the user.
-     * 
+     *
      * @return bool
      */
     public function isActivated()

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Google2FA;
 use Illuminate\Http\Request as IlluminateRequest;
 use PragmaRX\Google2FA\Support\Constants as Google2FAConstants;
-use PragmaRX\Google2FALaravel\Exceptions\InvalidOneTimePassword;
 use PragmaRX\Google2FALaravel\Exceptions\InvalidSecretKey;
 
 class Authenticator
@@ -63,13 +62,14 @@ class Authenticator
     }
 
     /**
-     * Check if the 2FA is activated for the user
+     * Check if the 2FA is activated for the user.
      * 
      * @return bool
      */
     public function isActivated()
     {
         $secret = $this->getGoogle2FASecretKey();
+
         return !is_null($secret) && !empty($secret);
     }
 
@@ -214,7 +214,7 @@ class Authenticator
     }
 
     /**
-     * Verify the OTP and store the timestamp
+     * Verify the OTP and store the timestamp.
      *
      * @return mixed
      */
@@ -227,5 +227,4 @@ class Authenticator
             )
         );
     }
-    
 }

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -33,7 +33,6 @@ class Authenticator
     public function boot($request)
     {
         $this->setRequest($request);
-
         return $this;
     }
 
@@ -42,7 +41,7 @@ class Authenticator
      *
      * @return bool
      */
-    public function canPassWithoutCheckingOTP()
+    protected function canPassWithoutCheckingOTP()
     {
         return
             !$this->isEnabled() ||
@@ -60,8 +59,7 @@ class Authenticator
      */
     protected function getGoogle2FASecretKey()
     {
-        $secret = $this->getUser()->{$this->config('otp_secret_column')};
-        return $secret;
+        return $this->getUser()->{$this->config('otp_secret_column')};
     }
 
     /**
@@ -76,7 +74,7 @@ class Authenticator
     }
 
     /**
-     * Store the old OTP.
+     * Store the old OTP timestamp.
      *
      * @param $key
      *
@@ -90,7 +88,7 @@ class Authenticator
     }
 
     /**
-     * Get the previous OTP.
+     * Get the previous OTP timestamp.
      *
      * @return null|void
      */
@@ -216,11 +214,11 @@ class Authenticator
     }
 
     /**
-     * Verify the OTP.
+     * Verify the OTP and store the timestamp
      *
      * @return mixed
      */
-    public function verifyAndStoreOneTimePassord($one_time_password)
+    protected function verifyAndStoreOneTimePassord($one_time_password)
     {
         return $this->storeOldTimeStamp(
             $this->verifyGoogle2FA(

--- a/src/Support/AuthenticatorController.php
+++ b/src/Support/AuthenticatorController.php
@@ -27,7 +27,7 @@ class AuthenticatorController extends Authenticator
      */
     public function __construct(IlluminateRequest $request)
     {
-        $this->boot($request);
+        parent::__construct($request);
     }
 
     /**
@@ -39,7 +39,7 @@ class AuthenticatorController extends Authenticator
      */
     public function boot($request)
     {
-        $this->setRequest($request);
+        parent::boot($request);
         return $this;
     }
 
@@ -72,7 +72,9 @@ class AuthenticatorController extends Authenticator
      */
     public function isAuthenticated()
     {
-        return $this->canPassWithoutCheckingOTP() ?? $this->checkOTP();
+        return $this->canPassWithoutCheckingOTP()
+            ? true
+            : $this->checkOTP();
     }
 
     /**

--- a/src/Support/AuthenticatorController.php
+++ b/src/Support/AuthenticatorController.php
@@ -2,12 +2,8 @@
 
 namespace PragmaRX\Google2FALaravel\Support;
 
-use Carbon\Carbon;
-use Google2FA;
 use Illuminate\Http\Request as IlluminateRequest;
-use PragmaRX\Google2FA\Support\Constants as Google2FAConstants;
 use PragmaRX\Google2FALaravel\Exceptions\InvalidOneTimePassword;
-use PragmaRX\Google2FALaravel\Exceptions\InvalidSecretKey;
 
 class AuthenticatorController extends Authenticator
 {
@@ -40,6 +36,7 @@ class AuthenticatorController extends Authenticator
     public function boot($request)
     {
         parent::boot($request);
+
         return $this;
     }
 

--- a/src/Support/AuthenticatorController.php
+++ b/src/Support/AuthenticatorController.php
@@ -21,11 +21,11 @@ class AuthenticatorController
     protected $password;
 
     /**
-     * The backend.
+     * The authenticator.
      *
      * @var
      */
-    protected $backend;
+    protected $authenticator;
 
 
     /**
@@ -47,7 +47,7 @@ class AuthenticatorController
      */
     public function boot($request)
     {
-        $this->backend = app(Authenticator::class)->boot($request);
+        $this->authenticator = app(Authenticator::class)->boot($request);
         $this->setRequest($request);
 
         return $this;
@@ -83,7 +83,7 @@ class AuthenticatorController
     public function isAuthenticated()
     {
         return
-            $this->backend->canPassWithoutCheckingOTP()
+            $this->authenticator->canPassWithoutCheckingOTP()
                 ? true
                 : $this->checkOTP();
     }
@@ -100,7 +100,7 @@ class AuthenticatorController
         }
 
         if ($isValid = $this->verifyGoogle2FA()) {
-            $this->backend->storeAuthPassed();
+            $this->authenticator->login();
         }
 
         return $isValid;
@@ -113,11 +113,6 @@ class AuthenticatorController
      */
     protected function verifyGoogle2FA()
     {
-        return $this->backend->storeOldOneTimePassord(
-            $this->backend->verifyGoogle2FA(
-                $this->backend->getGoogle2FASecretKey(),
-                $this->getOneTimePassword()
-            )
-        );
+        return $this->authenticator->verifyAndStoreOneTimePassord($this->getOneTimePassword());
     }
 }

--- a/src/Support/AuthenticatorController.php
+++ b/src/Support/AuthenticatorController.php
@@ -9,9 +9,9 @@ use PragmaRX\Google2FA\Support\Constants as Google2FAConstants;
 use PragmaRX\Google2FALaravel\Exceptions\InvalidOneTimePassword;
 use PragmaRX\Google2FALaravel\Exceptions\InvalidSecretKey;
 
-class AuthenticatorController
+class AuthenticatorController extends Authenticator
 {
-    use Auth, Config, ErrorBag, Input, Request, Response;
+    use ErrorBag, Input, Response;
 
     /**
      * The current password.
@@ -19,14 +19,6 @@ class AuthenticatorController
      * @var
      */
     protected $password;
-
-    /**
-     * The authenticator.
-     *
-     * @var
-     */
-    protected $authenticator;
-
 
     /**
      * Authenticator constructor.
@@ -47,9 +39,7 @@ class AuthenticatorController
      */
     public function boot($request)
     {
-        $this->authenticator = app(Authenticator::class)->boot($request);
         $this->setRequest($request);
-
         return $this;
     }
 
@@ -82,10 +72,7 @@ class AuthenticatorController
      */
     public function isAuthenticated()
     {
-        return
-            $this->authenticator->canPassWithoutCheckingOTP()
-                ? true
-                : $this->checkOTP();
+        return $this->canPassWithoutCheckingOTP() ?? $this->checkOTP();
     }
 
     /**
@@ -99,8 +86,8 @@ class AuthenticatorController
             return false;
         }
 
-        if ($isValid = $this->verifyGoogle2FA()) {
-            $this->authenticator->login();
+        if ($isValid = $this->verifyOneTimePassword()) {
+            $this->login();
         }
 
         return $isValid;
@@ -111,8 +98,8 @@ class AuthenticatorController
      *
      * @return mixed
      */
-    protected function verifyGoogle2FA()
+    protected function verifyOneTimePassword()
     {
-        return $this->authenticator->verifyAndStoreOneTimePassord($this->getOneTimePassword());
+        return $this->verifyAndStoreOneTimePassord($this->getOneTimePassword());
     }
 }

--- a/src/Support/AuthenticatorController.php
+++ b/src/Support/AuthenticatorController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace PragmaRX\Google2FALaravel\Support;
+
+use Carbon\Carbon;
+use Google2FA;
+use Illuminate\Http\Request as IlluminateRequest;
+use PragmaRX\Google2FA\Support\Constants as Google2FAConstants;
+use PragmaRX\Google2FALaravel\Exceptions\InvalidOneTimePassword;
+use PragmaRX\Google2FALaravel\Exceptions\InvalidSecretKey;
+
+class AuthenticatorController
+{
+    use Auth, Config, ErrorBag, Input, Request, Response;
+
+    /**
+     * The current password.
+     *
+     * @var
+     */
+    protected $password;
+
+    /**
+     * The backend.
+     *
+     * @var
+     */
+    protected $backend;
+
+
+    /**
+     * Authenticator constructor.
+     *
+     * @param IlluminateRequest $request
+     */
+    public function __construct(IlluminateRequest $request)
+    {
+        $this->boot($request);
+    }
+
+    /**
+     * Authenticator boot.
+     *
+     * @param $request
+     *
+     * @return Authenticator
+     */
+    public function boot($request)
+    {
+        $this->backend = app(Authenticator::class)->boot($request);
+        $this->setRequest($request);
+
+        return $this;
+    }
+
+    /**
+     * Get the OTP from user input.
+     *
+     * @throws InvalidOneTimePassword
+     *
+     * @return mixed
+     */
+    protected function getOneTimePassword()
+    {
+        if (!is_null($this->password)) {
+            return $this->password;
+        }
+
+        $this->password = $this->getInputOneTimePassword();
+
+        if (is_null($this->password) || empty($this->password)) {
+            throw new InvalidOneTimePassword('One Time Password cannot be empty.');
+        }
+
+        return $this->password;
+    }
+
+    /**
+     * Check if the current use is authenticated via OTP.
+     *
+     * @return bool
+     */
+    public function isAuthenticated()
+    {
+        return
+            $this->backend->canPassWithoutCheckingOTP()
+                ? true
+                : $this->checkOTP();
+    }
+
+    /**
+     * Check if the input OTP is valid.
+     *
+     * @return bool
+     */
+    protected function checkOTP()
+    {
+        if (!$this->inputHasOneTimePassword()) {
+            return false;
+        }
+
+        if ($isValid = $this->verifyGoogle2FA()) {
+            $this->backend->storeAuthPassed();
+        }
+
+        return $isValid;
+    }
+
+    /**
+     * Verify the OTP.
+     *
+     * @return mixed
+     */
+    protected function verifyGoogle2FA()
+    {
+        return $this->backend->storeOldOneTimePassord(
+            $this->backend->verifyGoogle2FA(
+                $this->backend->getGoogle2FASecretKey(),
+                $this->getOneTimePassword()
+            )
+        );
+    }
+}

--- a/src/Support/Input.php
+++ b/src/Support/Input.php
@@ -18,7 +18,7 @@ trait Input
     {
         return $this->getRequest()->input($this->config('otp_input'));
     }
-    
+
     abstract public function getRequest();
 
     abstract protected function config($string, $children = []);

--- a/src/Support/Input.php
+++ b/src/Support/Input.php
@@ -14,11 +14,11 @@ trait Input
         return $this->getRequest()->has($this->config('otp_input'));
     }
 
-    public function input($var)
+    protected function getInputOneTimePassword()
     {
-        return $this->getRequest()->input($var);
+        return $this->getRequest()->input($this->config('otp_input'));
     }
-
+    
     abstract public function getRequest();
 
     abstract protected function config($string, $children = []);


### PR DESCRIPTION
The Authenticator class is good, but is not very flexible.
This PR splits the Authenticator in 2 classes :
- AuthenticatorController, used by Middleware to handle login request
- Authenticator, which does not depend on the current request, and can be used manually.

Authenticator come with 3 new public functions :
- IsActivated : true if current user has activated 2fa (2fa should be activated/deactivated on demand)
- login : to force login when verification has been made manually in the application (old storeAuthPassed function)
- verifyGoogle2FA($secret, $one_time_password) : to check secret an OTP manually

canPassWithoutCheckingOTP checks if user has activated 2FA (if not, it lets pass without 2FA)
