### PR TITLE
Allow usage of google2FA in stateless APIs

### DIFF
--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -25,7 +25,7 @@ class Authenticator extends Google2FA
      *
      * @var
      */
-    protected $apiUsage = false;
+    protected $stateless = false;
 
     /**
      * Authenticator constructor.
@@ -62,7 +62,7 @@ class Authenticator extends Google2FA
     {
         parent::boot($request);
 
-        $this->apiUsage = true;
+        $this->stateless = true;
 
         return $this;
     }

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -21,6 +21,13 @@ class Authenticator extends Google2FA
     protected $password;
 
     /**
+     * Flag to disable the session for API usage.
+     *
+     * @var
+     */
+    protected $apiUsage = false;
+
+    /**
      * Authenticator constructor.
      *
      * @param \Illuminate\Http\Request $request
@@ -40,6 +47,22 @@ class Authenticator extends Google2FA
     public function boot($request)
     {
         parent::boot($request);
+
+        return $this;
+    }
+
+    /**
+     * Authenticator boot for API usage.
+     *
+     * @param $request
+     *
+     * @return Google2FA
+     */
+    public function bootApi($request)
+    {
+        parent::boot($request);
+
+        $this->apiUsage = true;
 
         return $this;
     }

--- a/src/Support/Session.php
+++ b/src/Support/Session.php
@@ -25,7 +25,7 @@ trait Session
      */
     public function sessionGet($var = null, $default = null)
     {
-        if($this->stateless) {
+        if ($this->stateless) {
             return $default;
         }
 
@@ -45,7 +45,7 @@ trait Session
      */
     protected function sessionPut($var, $value)
     {
-        if($this->stateless) {
+        if ($this->stateless) {
             return $value;
         }
 
@@ -64,7 +64,7 @@ trait Session
      */
     protected function sessionForget($var = null)
     {
-        if($this->stateless) {
+        if ($this->stateless) {
             return;
         }
 

--- a/src/Support/Session.php
+++ b/src/Support/Session.php
@@ -25,6 +25,10 @@ trait Session
      */
     public function sessionGet($var = null, $default = null)
     {
+        if($this->apiUsage) {
+            return $default;
+        }
+
         return $this->getRequest()->session()->get(
             $this->makeSessionVarName($var),
             $default
@@ -41,6 +45,10 @@ trait Session
      */
     protected function sessionPut($var, $value)
     {
+        if($this->apiUsage) {
+            return $value;
+        }
+
         $this->getRequest()->session()->put(
             $this->makeSessionVarName($var),
             $value
@@ -56,6 +64,10 @@ trait Session
      */
     protected function sessionForget($var = null)
     {
+        if($this->apiUsage) {
+            return;
+        }
+
         $this->getRequest()->session()->forget(
             $this->makeSessionVarName($var)
         );

--- a/src/Support/Session.php
+++ b/src/Support/Session.php
@@ -25,7 +25,7 @@ trait Session
      */
     public function sessionGet($var = null, $default = null)
     {
-        if($this->apiUsage) {
+        if($this->stateless) {
             return $default;
         }
 
@@ -45,7 +45,7 @@ trait Session
      */
     protected function sessionPut($var, $value)
     {
-        if($this->apiUsage) {
+        if($this->stateless) {
             return $value;
         }
 
@@ -64,7 +64,7 @@ trait Session
      */
     protected function sessionForget($var = null)
     {
-        if($this->apiUsage) {
+        if($this->stateless) {
             return;
         }
 


### PR DESCRIPTION
For stateless APIs use as follows:

$authenticator = app(Authenticator::class)->boot**Api**($request);
if ($authenticator->isAuthenticated()) {
    // otp auth success....
}