### PR TITLE
Laravel 5.2 Compatible

### DIFF
--- a/src/Events/EmptyOneTimePasswordReceived.php
+++ b/src/Events/EmptyOneTimePasswordReceived.php
@@ -2,11 +2,12 @@
 
 namespace PragmaRX\Google2FALaravel\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+//use Illuminate\Broadcasting\InteractsWithSockets;
+//use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class EmptyOneTimePasswordReceived
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    //use Dispatchable, InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 }

--- a/src/Events/LoggedOut.php
+++ b/src/Events/LoggedOut.php
@@ -2,13 +2,14 @@
 
 namespace PragmaRX\Google2FALaravel\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+//use Illuminate\Broadcasting\InteractsWithSockets;
+//use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class LoggedOut
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    //use Dispatchable, InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     public $user;
 

--- a/src/Events/LoginFailed.php
+++ b/src/Events/LoginFailed.php
@@ -2,13 +2,14 @@
 
 namespace PragmaRX\Google2FALaravel\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+//use Illuminate\Broadcasting\InteractsWithSockets;
+//use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class LoginFailed
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    //use Dispatchable, InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     public $user;
 

--- a/src/Events/LoginSucceeded.php
+++ b/src/Events/LoginSucceeded.php
@@ -2,13 +2,14 @@
 
 namespace PragmaRX\Google2FALaravel\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+//use Illuminate\Broadcasting\InteractsWithSockets;
+//use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class LoginSucceeded
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    //use Dispatchable, InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     public $user;
 

--- a/src/Events/OneTimePasswordExpired.php
+++ b/src/Events/OneTimePasswordExpired.php
@@ -2,12 +2,13 @@
 
 namespace PragmaRX\Google2FALaravel\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+//use Illuminate\Broadcasting\InteractsWithSockets;
+//use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class OneTimePasswordExpired
 {
+    //use Dispatchable, InteractsWithSockets, SerializesModels;
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public $user;

--- a/src/Events/OneTimePasswordRequested53.php
+++ b/src/Events/OneTimePasswordRequested53.php
@@ -2,13 +2,14 @@
 
 namespace PragmaRX\Google2FALaravel\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+//use Illuminate\Broadcasting\InteractsWithSockets;
+//use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
 class OneTimePasswordRequested53
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    //use Dispatchable, InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     public $user;
 


### PR DESCRIPTION
Removed two traits from your events in order to be compatible with Laravel 5.2: InteractsWithSockets and Dispatchable.

I was getting the same error as issue #12:

`FatalErrorException in OneTimePasswordRequested.php line 11:
Trait 'Illuminate\Foundation\Events\Dispatchable' not found` 

Now it seems to be working on my project.

Do you think this will impact the rest of the package?

Thanks!