### PR TITLE
Fix  'BaconQrCode\Renderer\Image\Png' not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=5.4",
         "laravel/framework": ">=5.2",
-        "pragmarx/google2fa": "~3.0"
+        "pragmarx/google2fa": "~3.0",
+        "bacon/bacon-qr-code": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7",
@@ -41,7 +42,6 @@
         }
     },
     "suggest": {
-      "bacon/bacon-qr-code": "Required to generate inline QR Codes.",
       "pragmarx/recovery": "Generate recovery codes."
     }
 }


### PR DESCRIPTION
Due to unspecifiedversion range in composer, this package is not compatible with new BaconQrCode releases.