### PR TITLE
fix inputHasOneTimePassword

### DIFF
--- a/src/Support/Input.php
+++ b/src/Support/Input.php
@@ -11,7 +11,7 @@ trait Input
      */
     protected function inputHasOneTimePassword()
     {
-        return $this->getRequest()->has($this->config('otp_input'));
+        return !empty($this->getInputOneTimePassword());
     }
 
     protected function getInputOneTimePassword()


### PR DESCRIPTION
the `has` method checks only for key existence and not the value. If the value is empty it's still `true` and leads to an exception.