### PR TITLE
Fix session stateless usage

### DIFF
--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -11,7 +11,7 @@ use PragmaRX\Google2FALaravel\Google2FA;
 
 class Authenticator extends Google2FA
 {
-    use ErrorBag, Input, Response;
+    use ErrorBag, Input, Response, Session;
 
     /**
      * The current password.
@@ -19,13 +19,6 @@ class Authenticator extends Google2FA
      * @var
      */
     protected $password;
-
-    /**
-     * Flag to disable the session for API usage.
-     *
-     * @var
-     */
-    protected $stateless = false;
 
     /**
      * Authenticator constructor.
@@ -104,14 +97,6 @@ class Authenticator extends Google2FA
     }
 
     /**
-     * @return mixed
-     */
-    public function getStateless()
-    {
-        return $this->stateless;
-    }
-
-    /**
      * Check if the current use is authenticated via OTP.
      *
      * @return bool
@@ -153,18 +138,6 @@ class Authenticator extends Google2FA
         }
 
         return $this->fireLoginEvent($isValid);
-    }
-
-    /**
-     * @param mixed $stateless
-     *
-     * @return Authenticator
-     */
-    public function setStateless($stateless = true)
-    {
-        $this->stateless = $stateless;
-
-        return $this;
     }
 
     /**

--- a/src/Support/Session.php
+++ b/src/Support/Session.php
@@ -5,6 +5,13 @@ namespace PragmaRX\Google2FALaravel\Support;
 trait Session
 {
     /**
+     * Flag to disable the session for API usage.
+     *
+     * @var bool
+     */
+    protected $stateless = false;
+
+    /**
      * Make a session var name for.
      *
      * @param null $name
@@ -71,6 +78,18 @@ trait Session
         $this->getRequest()->session()->forget(
             $this->makeSessionVarName($var)
         );
+    }
+
+    /**
+     * @param mixed $stateless
+     *
+     * @return Authenticator
+     */
+    public function setStateless($stateless = true)
+    {
+        $this->stateless = $stateless;
+
+        return $this;
     }
 
     abstract protected function config($string, $children = []);

--- a/tests/Google2FaLaravelTest.php
+++ b/tests/Google2FaLaravelTest.php
@@ -162,6 +162,20 @@ class Google2FaLaravelTest extends TestCase
         );
     }
 
+    public function testLogin()
+    {
+        $this->startSession();
+
+        $request = $this->createEmptyRequest();
+        $request->setLaravelSession($this->app['session']);
+
+        $authenticator = app(\PragmaRX\Google2FALaravel\Google2FA::class)->boot($request);
+
+        $authenticator->login();
+
+        $this->assertTrue($request->getSession()->get('google2fa.auth_passed'));
+    }
+
     public function testOldPasswords()
     {
         config(['google2fa.forbid_old_passwords' => true]);


### PR DESCRIPTION
With the recent session stateless feature, the Google2FA::login() function is not working anymore.
`stateless` property is used in `Session` Trait, and must exist in `Google2FA` class too.