### PR TITLE
Removed a redundant check

### DIFF
--- a/src/Support/Response.php
+++ b/src/Support/Response.php
@@ -32,7 +32,7 @@ trait Response
      */
     protected function makeStatusCode()
     {
-        return ! $this->checkOTP()
+        return !$this->checkOTP()
             ? SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY
             : SymfonyResponse::HTTP_OK;
     }

--- a/src/Support/Response.php
+++ b/src/Support/Response.php
@@ -32,10 +32,9 @@ trait Response
      */
     protected function makeStatusCode()
     {
-        return
-            $this->inputHasOneTimePassword() && !$this->checkOTP()
-                ? SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY
-                : SymfonyResponse::HTTP_OK;
+        return ! $this->checkOTP()
+            ? SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY
+            : SymfonyResponse::HTTP_OK;
     }
 
     /**


### PR DESCRIPTION
The input existence check is already being done within the function checkOTP, this duplication leads to a conflict as the function makeStatusCode returns SymfonyResponse::HTTP_OK when it should return SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY.