### PR TITLE
Fix ServiceProvider issues

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -37,7 +37,7 @@ class ServiceProvider extends IlluminateServiceProvider
             return $app->make(Google2FA::class);
         });
     }
-    
+
     public function boot()
     {
         $this->configurePaths();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,13 +7,6 @@ use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 class ServiceProvider extends IlluminateServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
-    /**
      * Configure package paths.
      */
     private function configurePaths()
@@ -34,16 +27,6 @@ class ServiceProvider extends IlluminateServiceProvider
     }
 
     /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return ['pragmarx.google2fa'];
-    }
-
-    /**
      * Register the service provider.
      *
      * @return void
@@ -53,7 +36,10 @@ class ServiceProvider extends IlluminateServiceProvider
         $this->app->singleton('pragmarx.google2fa', function ($app) {
             return $app->make(Google2FA::class);
         });
-
+    }
+    
+    public function boot()
+    {
         $this->configurePaths();
 
         $this->mergeConfig();


### PR DESCRIPTION
Closes #73 

There were a couple of issues with the ServiceProvider:

- According to [Laravel documentation](https://laravel.com/docs/5.7/providers#the-register-method) the register method should only used to bind things to the service container. This wasn't the case. Therefore, I moved the `configurePaths` and `mergeConfig` calls to the `boot` method.
- [Deferring a provider](https://laravel.com/docs/5.7/providers#deferred-providers) only works when it only registers to the service container, which isn't the case here. Therefore I removed `$defer = true` and the (now useless) `provides` method.

Currently I have to extend the provider in my own source code to make the config work properly, so I think merging this PR as soon as possible would be very helpful.