### PR TITLE
Allow configuring QR image backend

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -30,11 +30,11 @@ class Google2FA extends Google2FAService
 
         switch ($this->config('qr_image_backend')) {
             case 'svg':
-                parent::__construct(new \BaconQrCode\Renderer\Image\SvgImageBackEnd);
+                parent::__construct(new \BaconQrCode\Renderer\Image\SvgImageBackEnd());
                 break;
             
             case 'eps':
-                parent::__construct(new \BaconQrCode\Renderer\Image\EpsImageBackEnd);
+                parent::__construct(new \BaconQrCode\Renderer\Image\EpsImageBackEnd());
                 break;
 
             default:

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -28,7 +28,20 @@ class Google2FA extends Google2FAService
     {
         $this->boot($request);
 
-        parent::__construct();
+        switch ($this->config('qr_image_backend')) {
+            case 'svg':
+                parent::__construct(new \BaconQrCode\Renderer\Image\SvgImageBackEnd);
+                break;
+            
+            case 'eps':
+                parent::__construct(new \BaconQrCode\Renderer\Image\EpsImageBackEnd);
+                break;
+
+            default:
+                parent::__construct();
+                break;
+
+        }
     }
 
     /**

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -32,7 +32,7 @@ class Google2FA extends Google2FAService
             case 'svg':
                 parent::__construct(new \BaconQrCode\Renderer\Image\SvgImageBackEnd());
                 break;
-            
+
             case 'eps':
                 parent::__construct(new \BaconQrCode\Renderer\Image\EpsImageBackEnd());
                 break;

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -69,6 +69,12 @@ return [
     /*
      * Throw exceptions or just fire events?
      */
-    'throw_exceptions' => true,
+    'throw_exceptions' => false,
+
+    /*
+     * Which image backend to use for generating QR codes?
+     * (svg, eps, or null for ImageMagick)
+     */
+    'qr_image_backend' => 'svg',
 
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -69,7 +69,7 @@ return [
     /*
      * Throw exceptions or just fire events?
      */
-    'throw_exceptions' => false,
+    'throw_exceptions' => true,
 
     /*
      * Which image backend to use for generating QR codes?

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -75,6 +75,6 @@ return [
      * Which image backend to use for generating QR codes?
      * (svg, eps, or null for ImageMagick)
      */
-    'qr_image_backend' => 'svg',
+    'qr_image_backend' => null,
 
 ];


### PR DESCRIPTION
Allow users to use other (svg, eps) image backends for QR code generation.

Fixes #58 
