### PR TITLE
Fix the unknown error issue. Closes #60

### DIFF
--- a/src/Support/ErrorBag.php
+++ b/src/Support/ErrorBag.php
@@ -35,7 +35,7 @@ trait ErrorBag
                 config(
                     $statusCode == SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY
                         ? 'google2fa.error_messages.wrong_otp'
-                        : 'unknown error'
+                        : 'google2fa.error_messages.unknown'
                 )
             )
         );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -64,6 +64,7 @@ return [
     'error_messages' => [
         'wrong_otp'       => "The 'One Time Password' typed was wrong.",
         'cannot_be_empty' => 'One Time Password cannot be empty.',
+        'unknown'         => 'An unknown error has occurred. Please try again.',
     ],
 
     /*


### PR DESCRIPTION
This should fix the #60 issue which I've also encountered.

Previously, `config('unknown error')` returned `null`, and then `trans(null)` returned the instance of Laravel Translator, instead of a string. Laravel would then complain with an error similar to `Object of class Illuminate\Translation\FileLoader could not be converted to string`