### PR TITLE
Fix issue with OTP form showing an error message on first load

### DIFF
--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -138,6 +138,7 @@ class Authenticator extends Google2FA
         if ($isValid) {
             $this->login();
             $this->fireLoginEvent($isValid);
+
             return Constants::OTP_VALID;
         }
 

--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -85,7 +85,8 @@ class Authenticator extends Google2FA
      */
     protected function getOneTimePassword()
     {
-        if (is_null($password = $this->getInputOneTimePassword()) || empty($password)) {
+        $password = $this->getInputOneTimePassword();
+        if (is_null($password) || empty($password)) {
             event(new EmptyOneTimePasswordReceived());
 
             if ($this->config('throw_exceptions', true)) {
@@ -103,7 +104,7 @@ class Authenticator extends Google2FA
      */
     public function isAuthenticated()
     {
-        return $this->canPassWithoutCheckingOTP() || $this->checkOTP();
+        return $this->canPassWithoutCheckingOTP() || ($this->checkOTP() === Constants::OTP_VALID);
     }
 
     /**
@@ -121,21 +122,26 @@ class Authenticator extends Google2FA
     }
 
     /**
-     * Check if the input OTP is valid.
+     * Check if the input OTP is valid. Returns one of the possible OTP_STATUS codes:
+     * 'empty', 'valid' or 'invalid'.
      *
-     * @return bool
+     * @return string
      */
     protected function checkOTP()
     {
-        if (!$this->inputHasOneTimePassword()) {
-            return false;
+        if (!$this->inputHasOneTimePassword() || empty($this->getInputOneTimePassword())) {
+            return Constants::OTP_EMPTY;
         }
 
-        if ($isValid = $this->verifyOneTimePassword()) {
+        $isValid = $this->verifyOneTimePassword();
+
+        if ($isValid) {
             $this->login();
+            $this->fireLoginEvent($isValid);
+            return Constants::OTP_VALID;
         }
 
-        return $this->fireLoginEvent($isValid);
+        return Constants::OTP_INVALID;
     }
 
     /**

--- a/src/Support/Constants.php
+++ b/src/Support/Constants.php
@@ -17,4 +17,10 @@ class Constants
     const QRCODE_IMAGE_BACKEND_SVG = 'svg';
 
     const QRCODE_IMAGE_BACKEND_IMAGEMAGICK = 'imagemagick';
+
+    const OTP_EMPTY = 'empty';
+
+    const OTP_VALID = 'valid';
+
+    const OTP_INVALID = 'invalid';
 }

--- a/src/Support/ErrorBag.php
+++ b/src/Support/ErrorBag.php
@@ -32,8 +32,9 @@ trait ErrorBag
     {
         $errorMap = [
             SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY => 'google2fa.error_messages.wrong_otp',
-            SymfonyResponse::HTTP_BAD_REQUEST => 'google2fa.error_messages.cannot_be_empty'
+            SymfonyResponse::HTTP_BAD_REQUEST          => 'google2fa.error_messages.cannot_be_empty',
         ];
+
         return $this->createErrorBagForMessage(
             trans(
                 config(

--- a/src/Support/ErrorBag.php
+++ b/src/Support/ErrorBag.php
@@ -30,12 +30,14 @@ trait ErrorBag
      */
     protected function getErrorBagForStatusCode($statusCode)
     {
+        $errorMap = [
+            SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY => 'google2fa.error_messages.wrong_otp',
+            SymfonyResponse::HTTP_BAD_REQUEST => 'google2fa.error_messages.cannot_be_empty'
+        ];
         return $this->createErrorBagForMessage(
             trans(
                 config(
-                    $statusCode == SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY
-                        ? 'google2fa.error_messages.wrong_otp'
-                        : 'google2fa.error_messages.unknown'
+                    array_key_exists($statusCode, $errorMap) ? $errorMap[$statusCode] : 'google2fa.error_messages.unknown'
                 )
             )
         );

--- a/src/Support/Response.php
+++ b/src/Support/Response.php
@@ -38,6 +38,7 @@ trait Response
         if ($this->checkOTP() === Constants::OTP_EMPTY) {
             return SymfonyResponse::HTTP_BAD_REQUEST;
         }
+
         return SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY;
     }
 

--- a/src/Support/Response.php
+++ b/src/Support/Response.php
@@ -32,9 +32,13 @@ trait Response
      */
     protected function makeStatusCode()
     {
-        return !$this->checkOTP()
-            ? SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY
-            : SymfonyResponse::HTTP_OK;
+        if ($this->getRequest()->isMethod('get') || ($this->checkOTP() === Constants::OTP_VALID)) {
+            return SymfonyResponse::HTTP_OK;
+        }
+        if ($this->checkOTP() === Constants::OTP_EMPTY) {
+            return SymfonyResponse::HTTP_BAD_REQUEST;
+        }
+        return SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY;
     }
 
     /**

--- a/tests/Google2FaLaravelTest.php
+++ b/tests/Google2FaLaravelTest.php
@@ -270,7 +270,7 @@ class Google2FaLaravelTest extends TestCase
     public function testViewError()
     {
         config([
-            'google2fa.error_messages.cannot_be_empty' => self::EMPTY_OTP_ERROR_MESSAGE
+            'google2fa.error_messages.cannot_be_empty' => self::EMPTY_OTP_ERROR_MESSAGE,
         ]);
 
         $this->assertStringContainsString(

--- a/tests/Google2FaLaravelTest.php
+++ b/tests/Google2FaLaravelTest.php
@@ -12,14 +12,15 @@ use PragmaRX\Google2FALaravel\Tests\Support\User;
 
 class Google2FaLaravelTest extends TestCase
 {
-    const VIEW_ERROR_MESSAGE = 'WRONG OTP';
+    const WRONG_OTP_ERROR_MESSAGE = 'WRONG OTP';
+    const EMPTY_OTP_ERROR_MESSAGE = 'EMPTY OTP';
 
     /**
      * @return \Illuminate\Http\Request
      */
     private function createEmptyRequest()
     {
-        return $request = (new Request())->createFromBase(
+        return (new Request())->createFromBase(
             \Symfony\Component\HttpFoundation\Request::create(
                 '/',
                 'GET'
@@ -39,7 +40,9 @@ class Google2FaLaravelTest extends TestCase
     {
         parent::setup();
 
-        $this->app->make('Illuminate\Contracts\Http\Kernel')->pushMiddleware('Illuminate\Session\Middleware\StartSession');
+        $this->app->make('Illuminate\Contracts\Http\Kernel')
+            ->pushMiddleware('Illuminate\Session\Middleware\StartSession')
+            ->pushMiddleware('Illuminate\View\Middleware\ShareErrorsFromSession::class');
 
         \View::addLocation(__DIR__.'/views');
 
@@ -72,7 +75,7 @@ class Google2FaLaravelTest extends TestCase
 
     protected function assertLogin($password = null, $message = 'google2fa passed')
     {
-        config(['google2fa.error_messages.wrong_otp' => self::VIEW_ERROR_MESSAGE]);
+        config(['google2fa.error_messages.wrong_otp' => self::WRONG_OTP_ERROR_MESSAGE]);
 
         $renderedView = $this->call('POST', 'login', ['one_time_password' => $password])->getContent();
 
@@ -81,9 +84,9 @@ class Google2FaLaravelTest extends TestCase
             $renderedView
         );
 
-        if ($message !== self::VIEW_ERROR_MESSAGE) {
+        if ($message !== self::WRONG_OTP_ERROR_MESSAGE) {
             $this->assertStringNotContainsString(
-                self::VIEW_ERROR_MESSAGE,
+                self::WRONG_OTP_ERROR_MESSAGE,
                 $renderedView
             );
         }
@@ -148,7 +151,7 @@ class Google2FaLaravelTest extends TestCase
 
     public function testWrongOTP()
     {
-        $this->assertLogin('9999999', self::VIEW_ERROR_MESSAGE);
+        $this->assertLogin('9999999', self::WRONG_OTP_ERROR_MESSAGE);
     }
 
     public function testLogout()
@@ -266,10 +269,12 @@ class Google2FaLaravelTest extends TestCase
 
     public function testViewError()
     {
-        config(['google2fa.error_messages.wrong_otp' => self::VIEW_ERROR_MESSAGE]);
+        config([
+            'google2fa.error_messages.cannot_be_empty' => self::EMPTY_OTP_ERROR_MESSAGE
+        ]);
 
         $this->assertStringContainsString(
-            self::VIEW_ERROR_MESSAGE,
+            self::EMPTY_OTP_ERROR_MESSAGE,
             $this->call('POST', 'login', ['input_one_time_password_missing' => 'missing'])->getContent()
         );
     }


### PR DESCRIPTION
Fixes #72 

I added some new constants and used an `HTTP_BAD_REQUEST` to represent an empty OTP submission. The original `checkOTP()` function seemed to be the last check before inputs were passed to the proper Google2FA library for parsing/saving, so I made it a bit more verbose to handle the different conditions. It also assumes a GET request should pass, since credentials are only POSTed for validation.