### PR TITLE
Make 2FA persistent by using the database

### DIFF
--- a/.idea/google2fa-laravel-forked.iml
+++ b/.idea/google2fa-laravel-forked.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="PragmaRX\Google2FALaravel\" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="false" packagePrefix="PragmaRX\Google2FALaravel\Tests\" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/google2fa-laravel-forked.iml" filepath="$PROJECT_DIR$/.idea/google2fa-laravel-forked.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpIncludePathManager">
+    <include_path>
+      <path value="" />
+    </include_path>
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="7" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -15,6 +15,20 @@ return [
     'lifetime' => 0, // 0 = eternal
 
     /*
+     * Make persistent by using a database column.
+     *
+     * In case you need the lifetime to be greater than the lifespan of your current session. (ex: used for remember_me)
+     */
+    'remember' => true,
+
+    /*
+     *User's table column to use for persistent 2FA.
+     *
+     * Column type should be timestamp.
+     */
+    'remember_column' => 'google2fa_remember',
+
+    /*
      * Renew lifetime at every new request.
      */
     'keep_alive' => true,


### PR DESCRIPTION
### Problem
There is a limitation in the current state of the library in which the 2FA stays alive whilst the current session is alive. That means that `remember_me` functionalities and cookie-based approaches do not have the choice to provide long-term 2FA authentication and the OTP will be asked as soon as the session is expired.

### Fix
By using a database column, we can give the choice of a persistent 2FA without being dependent on the session's lifespan. The column is a timestamp and it will be populated with the current time as soon as the OTP is provided and there is a `remember_me` cookie set in the user's browser.

The new `twoFactorAuthStillValid` will check if the user enabled the `remember` functionality and will pass the check by comparing the timestamp taken on the login with the current_time plus the `lifetime` of the config.

### Bugs and considerations
1. Keep in mind that the check in line #229 in `Google2FA.php` just checks for the default `remember_me` cookie of Laravel and there is no validation that the cookie is indeed valid.

2. This PR doesn't play well with `lifetime=0` (as you can see in the `twoFactorAuthStillValid` method) and it would need a hacky way to make it for eternity by passing a large amount of time (like 100 years or something). I will leave this up to you.

### Final Notes
These changes will allow to the lifetime of the 2FA to be greater than the session's lifetime.
This way, users can stay "2FA authenticated" for a greater amount of time and not be limited by the session's lifespan.