### PR TITLE
Remove explicit mention of bacon/bacon-qr-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ Use Composer to install it:
 
     composer require pragmarx/google2fa-laravel
 
-If you prefer inline QRCodes instead of a Google generated url, you'll need to install [BaconQrCode](https://github.com/Bacon/BaconQrCode):
-
-    composer require bacon/bacon-qr-code
 
 ## Installing on Laravel
 


### PR DESCRIPTION
It's already installed as part of the regular dependency:
```
composer.phar require pragmarx/google2fa-laravel

Using version ^1.3 for pragmarx/google2fa-laravel
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 6 installs, 1 update, 0 removals
  - Installing dasprid/enum (1.0.0): Downloading (100%)
  - Installing bacon/bacon-qr-code (2.0.0): Downloading (100%)
  - Installing paragonie/constant_time_encoding (v2.3.0): Downloading (100%)
  - Installing pragmarx/google2fa (v7.0.0): Downloading (100%)
  - Installing pragmarx/google2fa-qrcode (v1.0.3): Downloading (100%)
  - Installing pragmarx/google2fa-laravel (v1.3.1): Downloading (100%)
pragmarx/google2fa-laravel suggests installing pragmarx/recovery (Generate recovery codes.)
Package guzzlehttp/ringphp is abandoned, you should avoid using it. No replacement was suggested.
Package guzzlehttp/streams is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
```
This reason is that this package depends `google2fa-qrcode` which already depends on `bacon/bacon-qr-code`:
```
$ composer.phar depends bacon/bacon-qr-code
pragmarx/google2fa-qrcode  v1.0.3  requires  bacon/bacon-qr-code (~1.0|~2.0)
```
Maybe there's a reason to keep it in the readme, in which case just ignore my PR. Just isn't obvious to me why it's explicitly mentioned.

Thanks!