### PR TITLE
fire event for login failed

### DIFF
--- a/src/Support/Authenticator.php
+++ b/src/Support/Authenticator.php
@@ -145,6 +145,8 @@ class Authenticator extends Google2FA
             return Constants::OTP_VALID;
         }
 
+        $this->fireLoginEvent($isValid);
+
         return Constants::OTP_INVALID;
     }
 


### PR DESCRIPTION
This will fire a `LoginFailed` event when an invalid TOTP code is used.