### PR TITLE
Use simply string to store in session instead of an object

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -245,7 +245,7 @@ class Google2FA extends Google2FAService
      */
     protected function updateCurrentAuthTime()
     {
-        $this->sessionPut(Constants::SESSION_AUTH_TIME, Carbon::now());
+        $this->sessionPut(Constants::SESSION_AUTH_TIME, Carbon::now()->toIso8601String());
     }
 
     /**


### PR DESCRIPTION
I want to propose the following change for, which seems, very exotic reason.

In my environment I share the PHP session with other non-PHP services. This alone is already a challenge due to the native PHP session format (also when e.g. stored in redis) is custom.

Currently this means e.g. NodeJS where I found solution which can de-serialize the session.

However this won't work when "objects" are involved. The unserialize implementations for JavaScript at best can unserialize `stdClass` but they don't know how to handle `\Carbon\Carbon`.

The current code being:
```php
        $this->sessionPut(Constants::SESSION_AUTH_TIME, Carbon::now());
```
though stores an actual "object" in the session, complicating matters.

I therefore suggest to simply store the string representation.

To the best of my knowledge this doesn't break anything and the only place consuming the `auth_time` is `\PragmaRX\Google2FALaravel\Google2FA::minutesSinceLastActivity` which _also_ uses Carbon (`diffInMinutes`) which will transparently accept this; here from a tinker session:
```
>>> $now = \Carbon\Carbon::now()->toIso8601String();
=> "2020-04-04T20:34:16+00:00"

… let some time pass …

>>> \Carbon\Carbon::now()->diffInMinutes($now);
=> 1
```