### PR TITLE
Add explicit support for Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,42 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 # - nightly
-
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
 
 ## Cache composer
 cache:
   directories:
     - $HOME/.composer/cache
 
+env:
+  - LARAVEL_VERSION=5.8.* TESTBENCH_VERSION=3.8.*
+  - LARAVEL_VERSION=6.* TESTBENCH_VERSION=4.*
+  - LARAVEL_VERSION=7.* TESTBENCH_VERSION=5.*
+  - LARAVEL_VERSION=8.* TESTBENCH_VERSION=6.*
+
+matrix:
+  exclude:
+    - php: 7.1
+      env: LARAVEL_VERSION=6.* TESTBENCH_VERSION=4.*
+    - php: 7.1
+      env: LARAVEL_VERSION=7.* TESTBENCH_VERSION=5.*
+    - php: 7.1
+      env: LARAVEL_VERSION=8.* TESTBENCH_VERSION=6.*
+    - php: 7.2
+      env: LARAVEL_VERSION=8.* TESTBENCH_VERSION=6.*
+
 before_script:
   - yes '' | pecl install imagick
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
+  - composer require "laravel/framework:${LARAVEL_VERSION}" "orchestra/testbench:${TESTBENCH_VERSION}" --no-update
+  - travis_retry composer update --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == '7.3' ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == '7.4' ]]; then
       wget https://scrutinizer-ci.com/ocular.phar
       php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.4.36",
+        "laravel/framework": ">=5.4.36|^8.0",
         "pragmarx/google2fa-qrcode": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8",
-        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*"
+        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,7 @@
     "suggest": {
       "bacon/bacon-qr-code": "Required to generate inline QR Codes.",
       "pragmarx/recovery": "Generate recovery codes."
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/Support/User.php
+++ b/tests/Support/User.php
@@ -60,11 +60,12 @@ class User extends Authenticatable
     /**
      * Retrieve the model for a bound value.
      *
-     * @param mixed $value
+     * @param mixed       $value
+     * @param string|null $field
      *
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveRouteBinding($value)
+    public function resolveRouteBinding($value, $field = null)
     {
         // TODO: Implement resolveRouteBinding() method.
     }


### PR DESCRIPTION
## Summary
- Add Support for Laravel 8 (composer version)
- Adapt changed signature of `resolveRouteBinding`
- Improve travis testing matrix to _actually_ test against specific Laravel versions
- composer: all dev dependencies to be installed but prefer stable