### PR TITLE
Improve PHP 8 compatibility by not defaulting to imagemagick

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -79,6 +79,6 @@ return [
      *
      * Supports imagemagick, svg and eps
      */
-    'qrcode_image_backend' => \PragmaRX\Google2FALaravel\Support\Constants::QRCODE_IMAGE_BACKEND_IMAGEMAGICK,
+    'qrcode_image_backend' => \PragmaRX\Google2FALaravel\Support\Constants::QRCODE_IMAGE_BACKEND_SVG,
 
 ];


### PR DESCRIPTION
Currently the imagemagick plugin does not officially support PHP 8.
For example: Heroku does not support the imagemagick for PHP 8.