### PR TITLE
Ability to set window dynamically

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -79,7 +79,7 @@ class Google2FA extends Google2FAService
     public function boot($request)
     {
         $this->setRequest($request);
-        
+
         $this->setWindow($this->config('window'));
 
         return $this;

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -79,6 +79,8 @@ class Google2FA extends Google2FAService
     public function boot($request)
     {
         $this->setRequest($request);
+        
+        $this->setWindow($this->config('window'));
 
         return $this;
     }
@@ -261,7 +263,7 @@ class Google2FA extends Google2FAService
         return $this->verifyKey(
             $secret,
             $one_time_password,
-            $this->config('window'),
+            $this->getWindow(),
             null, // $timestamp
                 $this->getOldTimestamp() ?: null
         );


### PR DESCRIPTION
I'd like to propose the following change to allow updating the window value dynamically.

The following function currently access `$this->config('window')`, and therefore `$this->setWindow()` will not work anymore.

```
public function verifyGoogle2FA($secret, $one_time_password)
    {
        return $this->verifyKey(
            $secret,
            $one_time_password,
            $this->config('window'),
            null, // $timestamp
                $this->getOldTimestamp() ?: null
        );
    }
```

Updating `$this->config('window')` to `$this->getWindow()` will solve this. And the value from config can be set as  default from the boot method.

A use case is explained in #142 

It would be great if this can be merged, please let me know if there's a better way or any changes are required.

Thanks!

@antonioribeiro 