### PR TITLE
Fix: test case - testQrcodeInline - checking if svg instead of base64

### DIFF
--- a/tests/Google2FaLaravelTest.php
+++ b/tests/Google2FaLaravelTest.php
@@ -251,7 +251,7 @@ class Google2FaLaravelTest extends TestCase
         $qrCode = Google2FA::getQRCodeInline('company name', 'email@company.com', Constants::SECRET);
 
         $this->assertStringStartsWith(
-            'data:image/png;base64',
+            '<?xml version="1.0"',
             $qrCode
         );
 


### PR DESCRIPTION
Since the default QRcode backend has been changed to SVG, the test testQrcodeInline is failing. Updated test case to check if the output is XML.