### PR TITLE
Fix "Object of class Illuminate\Translation\FileLoader could not be converted to string"

### DIFF
--- a/src/Support/ErrorBag.php
+++ b/src/Support/ErrorBag.php
@@ -38,7 +38,8 @@ trait ErrorBag
         return $this->createErrorBagForMessage(
             trans(
                 config(
-                    array_key_exists($statusCode, $errorMap) ? $errorMap[$statusCode] : 'google2fa.error_messages.unknown'
+                    array_key_exists($statusCode, $errorMap) ? $errorMap[$statusCode] : 'google2fa.error_messages.unknown',
+                    'google2fa.error_messages.unknown'
                 )
             )
         );


### PR DESCRIPTION
If the config value for an error message (eg `google2fa.error_messages.cannot_be_empty`) is not set then `config()` will return `null`, which causes `trans()` to return a `Translator` object instead of a string, which then causes an exception in the `MessageBag` constructor because it expects a string.

This patch will make `config()` fall back to `trans(google2fa.error_messages.unknown)` if the config value is empty.