### PR TITLE
Add a Listener to login via remember

### DIFF
--- a/src/Listeners/LoginViaRemember.php
+++ b/src/Listeners/LoginViaRemember.php
@@ -3,8 +3,8 @@
 namespace PragmaRX\Google2FALaravel\Listeners;
 
 use Illuminate\Auth\Events\Login;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\Auth\Authenticatable as User;
+use Illuminate\Support\Facades\Auth;
 use PragmaRX\Google2FALaravel\Facade as Google2FA;
 
 class LoginViaRemember
@@ -12,7 +12,8 @@ class LoginViaRemember
     /**
      * Handle the event.
      *
-     * @param  \Illuminate\Auth\Events\Login  $event
+     * @param \Illuminate\Auth\Events\Login $event
+     *
      * @return void
      */
     public function handle(Login $event)
@@ -25,7 +26,7 @@ class LoginViaRemember
     /**
      * Force register Google2fa login.
      *
-     * @param  User  $user
+     * @param User $user
      */
     private function registerGoogle2fa(User $user)
     {

--- a/src/Listeners/LoginViaRemember.php
+++ b/src/Listeners/LoginViaRemember.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PragmaRX\Google2FALaravel\Listeners;
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Auth\Authenticatable as User;
+use PragmaRX\Google2FALaravel\Facade as Google2FA;
+
+class LoginViaRemember
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Auth\Events\Login  $event
+     * @return void
+     */
+    public function handle(Login $event)
+    {
+        if (Auth::viaRemember()) {
+            $this->registerGoogle2fa($event->user);
+        }
+    }
+
+    /**
+     * Force register Google2fa login.
+     *
+     * @param  User  $user
+     */
+    private function registerGoogle2fa(User $user)
+    {
+        $secret = $user->{Google2FA::config('otp_secret_column')};
+
+        if (!is_null($secret) && !empty($secret)) {
+            Google2FA::login();
+        }
+    }
+}


### PR DESCRIPTION
This can fix https://github.com/antonioribeiro/google2fa/issues/169

Just add this in your `App\Providers\EventServiceProvider` class:

```php
use Illuminate\Auth\Events\Login;
use PragmaRX\Google2FALaravel\Listeners\LoginViaRemember;

class EventServiceProvider extends ServiceProvider
{
    protected $listen = [
        Login::class => [
            LoginViaRemember::class,
        ],
    ];
...
```

When the session cookie is lost/expired, the `remember` cookie is used, and the `Login` event is triggered. This new listener handles this event to force 2fa login.