### PR TITLE
Allow upgrade laravel to 9.x and phpunit to 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.4.36|^8.0",
+        "laravel/framework": ">=5.4.36|^8.0|^9.0",
         "pragmarx/google2fa-qrcode": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5|~6|~7|~8",
+        "phpunit/phpunit": "~5|~6|~7|~8|~9",
         "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*",
         "bacon/bacon-qr-code": "^2.0"
     },


### PR DESCRIPTION
This PR allows the usage of Laravel 9.0 (and phpunit 9.x). 

Fixes: https://github.com/antonioribeiro/google2fa-laravel/issues/162