### PR TITLE
Update Laravel Constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.4.36|^8.0|^9.0",
+        "laravel/framework": ">=5.4.36|^6.0|^7.0|^8.0|^9.0",
         "pragmarx/google2fa-qrcode": "^1.0|^2.0|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.4.36|^6.0|^7.0|^8.0|^9.0",
+        "laravel/framework": "^5.4.36|^6.0|^7.0|^8.0|^9.0",
         "pragmarx/google2fa-qrcode": "^1.0|^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This enable installs on laravel 6 & 7, the readme says it's supported but the composer.json doesn't include these versions.