### PR TITLE
Laravel 10.x Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can scan the QR code on [this (old) demo page](https://antoniocarlosribeiro.
 |---------|-----------|-------------------|
 | 4.2     | <= 1.0.1  |                   |
 | 5.0-5.1 | <= 1.0.1  |                   |
-| 5.2-8.x | >= 2.0.0  | >= 0.2.0          |
+| 5.2-10.x | >= 2.0.0  | >= 0.2.0          |
 
 Before Google2FA 2.0 (Laravel 5.1) you have to install `pragmarx/google2fa:~1.0`, because this package was both a Laravel package and a PHP (agnostic).   
 

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.4.36|^8.0|^9.0",
+        "laravel/framework": ">=5.4.36|^8.0|^9.0|^10.0",
         "pragmarx/google2fa-qrcode": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8|~9",
-        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*",
+        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*|8.*",
         "bacon/bacon-qr-code": "^2.0"
     },
     "autoload": {

--- a/tests/Google2FaLaravelTest.php
+++ b/tests/Google2FaLaravelTest.php
@@ -184,7 +184,7 @@ class Google2FaLaravelTest extends TestCase
         $this->startSession();
 
         $request = $this->createEmptyRequest();
-        $request->setLaravelSession($this->app['session']);
+        $request->setLaravelSession($this->app['session.store']);
 
         $authenticator = app(\PragmaRX\Google2FALaravel\Google2FA::class)->boot($request);
 


### PR DESCRIPTION
Fixes #181 

- Increased composer.json to allow laravel/framework `>=5.4.36|^8.0|^9.0|^10.0`
- Optionally allowing orchestra/testbench v7 or v8 `3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*|8.*`
- Fixed testLogin to use `session.store` (driver) instead of `session` (manager) - was throwing:

```
1) PragmaRX\Google2FALaravel\Tests\Google2FaLaravelTest::testLogin
TypeError: Illuminate\Session\SymfonySessionDecorator::__construct(): Argument #1 ($store) must be of type Illuminate\Contracts\Session\Session, Illuminate\Session\SessionManager given, called in vendor/laravel/framework/src/Illuminate/Http/Request.php on line 545
```