### PR TITLE
Inertia views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 vendor
 coverage/*
+.idea/*

--- a/src/Support/Response.php
+++ b/src/Support/Response.php
@@ -91,7 +91,7 @@ trait Response
     private function getView()
     {
         if ($this->config('type_view') === 'inertia') {
-            return Inertia\Inertia::render($this->config('view'))->toResponse($this->getRequest())->throwResponse();
+            return \Inertia\Inertia::render($this->config('view'))->toResponse($this->getRequest())->throwResponse();
         }
 
         return view($this->config('view'));

--- a/src/Support/Response.php
+++ b/src/Support/Response.php
@@ -90,6 +90,10 @@ trait Response
      */
     private function getView()
     {
+        if ($this->config('type_view') === 'inertia') {
+            return Inertia\Inertia::render($this->config('view'))->toResponse($this->getRequest())->throwResponse();
+        }
+
         return view($this->config('view'));
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -55,6 +55,11 @@ return [
     'otp_secret_column' => 'google2fa_secret',
 
     /*
+     * Type of user view, blade or inertia
+     */
+    'type_view' => 'blade',
+
+    /*
      * One Time Password View.
      */
     'view' => 'google2fa.index',


### PR DESCRIPTION
Now you can set in the config the view_type value that can be inertia or blade (blade for default). If you set to inertia the Reponse class will return a Inertia::render view so can work with vuejs and inertia option in laravel.

Added option in config to select blade or inertia views.
Modify the Response class to return the blade or inertia view in function of the value in the config.