### PR TITLE
gha: add workflow for running phpunit

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,69 @@
+name: Tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/run-tests.yml'
+      - 'composer.json'
+      - 'phpunit.xml'
+      - 'src/**'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '.github/workflows/run-tests.yml'
+      - 'composer.json'
+      - 'phpunit.xml'
+      - 'src/**'
+      - 'tests/**'
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  php-tests:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [
+          8.3,
+          8.2,
+          8.1,
+          8.0,
+          7.4,
+          7.3,
+          7.2,
+        ]
+
+    name: P${{ matrix.php }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: pdo_sqlite, fileinfo
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist
+
+      - name: phpunit
+        run: vendor/bin/phpunit


### PR DESCRIPTION
Hello 👋🏼 ,

I would like to propose to add github action workflow to run phpunit tests for this package. I don't think the travis configuration still works / is in use.

This is a simple version to start with and only tests various PHP versions.

It does not (yet) test combination of "Laravel version with PHP versions". Currently running the CI tests against these PHP versions will use the highest possible Laravel version based on the overall version constraints (PHP 8+ gets Laravel 10, below that I've seen L9, 8 and 7).

I'm happy to extend in a further iteration if you accept this PR. The idea would also to prepare for Laravel 11 and have an automated test infrastructure ready for that.

Thank you!