### PR TITLE
Add session to readme about 2fa and laravel login via remember

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,24 @@ protected $routeMiddleware = [
 ];
 ```
 
+## 2FA and Laravel login via remember 
+
+When Laravel login via remember is activated, the session is renovated and the 2FA code is required again. To solve this, add the ``LoginViaRemember`` listener in your ``App\Providers\EventServiceProvider``:
+
+``` php
+use Illuminate\Auth\Events\Login;
+use PragmaRX\Google2FALaravel\Listeners\LoginViaRemember;
+
+class EventServiceProvider extends ServiceProvider
+{
+    protected $listen = [
+        Login::class => [
+            LoginViaRemember::class,
+        ],
+    ];
+...
+```
+
 ## Events
 
 The following events are fired:


### PR DESCRIPTION
A session in the README file about how one should deal with Laravel login via remember and the 2FA authentication was missing. This PR adds it.