### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,69 @@
+name: Tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/run-tests.yml'
+      - 'composer.json'
+      - 'phpunit.xml'
+      - 'src/**'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '.github/workflows/run-tests.yml'
+      - 'composer.json'
+      - 'phpunit.xml'
+      - 'src/**'
+      - 'tests/**'
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  php-tests:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [
+          8.3,
+          8.2,
+          8.1,
+          8.0,
+          7.4,
+          7.3,
+          7.2,
+        ]
+
+    name: P${{ matrix.php }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: pdo_sqlite, fileinfo
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist
+
+      - name: phpunit
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 vendor
 coverage/*
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": "^5.4.36|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "^5.4.36|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "pragmarx/google2fa-qrcode": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5|~6|~7|~8|~9",
-        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*|8.*",
+        "phpunit/phpunit": "~5|~6|~7|~8|~9|~10",
+        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*|8.*|9.*",
         "bacon/bacon-qr-code": "^2.0"
     },
     "autoload": {

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -267,7 +267,7 @@ class Google2FA extends Google2FAService
             $one_time_password,
             $this->getWindow(),
             null, // $timestamp
-                $this->getOldTimestamp() ?: null
+            $this->getOldTimestamp() ?: null
         );
     }
 

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -165,7 +165,8 @@ class Google2FA extends Google2FAService
     protected function minutesSinceLastActivity()
     {
         return Carbon::now()->diffInMinutes(
-            $this->sessionGet(Constants::SESSION_AUTH_TIME)
+            $this->sessionGet(Constants::SESSION_AUTH_TIME),
+            true
         );
     }
 


### PR DESCRIPTION
## Summary
- This PR already includes https://github.com/antonioribeiro/google2fa-laravel/pull/192
- bump composer verrsions
- needed a fix in `\PragmaRX\Google2FALaravel\Google2FA::minutesSinceLastActivity` due to behaviour change in `Carbon` due to a newer version installed with Laravle 11
  - that argument change is backwards compatible, the default of this `$absolute` arg was `true` but changed to `false` in recent releases

### Notes
- Once merged, I can add a text matrix for supported PHP + Laravel versions (right now, only the PHP version and the matching highest Laravel version, including L11, is tested)
- the successful GHA run can be seen at https://github.com/mfn/google2fa-laravel/actions/runs/8253895412