### PR TITLE
Add support for Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [
+          8.4,
           8.3,
           8.2,
           8.1,

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,8 +38,18 @@ jobs:
           7.3,
           7.2,
         ]
+        laravel: [
+          ^12,
+          ^11,
+          ^10,
+          ^9,
+          ^8,
+          ^7,
+          ^6,
+          ^5.4.36,
+        ]
 
-    name: P${{ matrix.php }}
+    name: P${{ matrix.php }} L${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -51,6 +61,8 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
           extensions: pdo_sqlite, fileinfo
+
+      - run: composer require laravel/framework:${{ matrix.laravel }} --no-update
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -76,7 +76,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer update --prefer-dist
+        run: composer update --prefer-dist --no-plugins
 
       - name: phpunit
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,6 +48,69 @@ jobs:
           ^6,
           ^5.4.36,
         ]
+        exclude:
+          - php: 8.4
+            laravel: ^7
+          - php: 8.4
+            laravel: ^6
+          - php: 8.4
+            laravel: ^5.4.36
+          - php: 8.3
+            laravel: ^7
+          - php: 8.3
+            laravel: ^6
+          - php: 8.3
+            laravel: ^5.4.36
+          - php: 8.2
+            laravel: ^7
+          - php: 8.2
+            laravel: ^6
+          - php: 8.2
+            laravel: ^5.4.36
+          - php: 8.1
+            laravel: ^12
+          - php: 8.1
+            laravel: ^11
+          - php: 8.1
+            laravel: ^7
+          - php: 8.1
+            laravel: ^6
+          - php: 8.1
+            laravel: ^5.4.36
+          - php: 8.0
+            laravel: ^12
+          - php: 8.0
+            laravel: ^11
+          - php: 8.0
+            laravel: ^10
+          - php: 8.0
+            laravel: ^5.4.36
+          - php: 7.4
+            laravel: ^12
+          - php: 7.4
+            laravel: ^11
+          - php: 7.4
+            laravel: ^10
+          - php: 7.4
+            laravel: ^9
+          - php: 7.3
+            laravel: ^12
+          - php: 7.3
+            laravel: ^11
+          - php: 7.3
+            laravel: ^10
+          - php: 7.3
+            laravel: ^9
+          - php: 7.2
+            laravel: ^12
+          - php: 7.2
+            laravel: ^11
+          - php: 7.2
+            laravel: ^10
+          - php: 7.2
+            laravel: ^9
+          - php: 7.2
+            laravel: ^8
 
     name: P${{ matrix.php }} L${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": "^5.4.36|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "laravel/framework": "^5.4.36|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "pragmarx/google2fa-qrcode": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5|~6|~7|~8|~9|~10",
-        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*|8.*|9.*",
+        "phpunit/phpunit": "~5|~6|~7|~8|~9|~10|~11",
+        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*|8.*|9.*|10.*",
         "bacon/bacon-qr-code": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Same procedure as every year ;) -> https://github.com/antonioribeiro/google2fa-laravel/pull/196
- Laravel 12 is not released yet, but everything is prepared for it
- adjusted github action to ensure we test the actual PHP & Laravel combinations
  - added exclude list for invalid combinations
- Added composer `--no-plugins` because in some older version combinations some dependencies install composer plugins, which would need to be whitelisted etc. -> not worth it