### PR TITLE
fix: cast minutes since last activity to int

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -164,7 +164,7 @@ class Google2FA extends Google2FAService
      */
     protected function minutesSinceLastActivity()
     {
-        return Carbon::now()->diffInMinutes(
+        return (int) Carbon::now()->diffInMinutes(
             $this->sessionGet(Constants::SESSION_AUTH_TIME),
             true
         );


### PR DESCRIPTION
Currently, all `Carbon::diffIn*` methods return float.
Wiki: https://carbon.nesbot.com/guide/getting-started/migration.html#diffin
